### PR TITLE
Fix Codeblock of arr.reduce() alternative 

### DIFF
--- a/book/templating/template-literals.md
+++ b/book/templating/template-literals.md
@@ -81,7 +81,7 @@ const div = (strings, ...args) => {
 
   for(let index = 0; index < strings.length; index++) {
     const interpolatedString = (args[index] || "");
-    acc += string[index] + interpolatedString;
+    acc += strings[index] + interpolatedString;
   }
 
   return acc;

--- a/book/templating/template-literals.md
+++ b/book/templating/template-literals.md
@@ -79,9 +79,9 @@ If you're not familiar with `Array.reduce`, it's the same as:
 const div = (strings, ...args) => {
   let acc = "";
 
-  for(const currentString of strings) {
-    const interpolatedString = (args[index] || ""):
-    acc += currentString + interpolatedString;
+  for(let index = 0; index < strings.length; index++) {
+    const interpolatedString = (args[index] || "");
+    acc += string[index] + interpolatedString;
   }
 
   return acc;


### PR DESCRIPTION
The index inside args[index] is not defined so fixed it by using a regular for loop.

Also replaced the ':' with a ';'